### PR TITLE
Import Gitify docs

### DIFF
--- a/en/50_Open_Source/Gitify/01_Installation/01_Windows.md
+++ b/en/50_Open_Source/Gitify/01_Installation/01_Windows.md
@@ -1,0 +1,32 @@
+On Windows, some of the installation steps are bit more work, especially adding Gitify to your `PATH` variable.
+
+This question on Stack Overflow explains the procedure of editing the PATH variable on Windows 7: http://stackoverflow.com/questions/7307548/how-to-access-php-with-the-command-line-on-windows/7307581#7307581
+
+It's common on Windows that you need to add PHP, MySQL and the Gitify executables to the PATH. 
+
+Common locations of the PHP executable on windows include:
+
+````
+c:\php\php.exe
+c:\php5\php.exe
+c:\windows\php.exe
+c:\program files\php\php.exe
+c:\wamp\bin\php\php5\php.exe
+c:\xampp\php\php.exe
+<ampps root>\php\php.exe
+````
+
+### Additional Dependencies
+
+Here are the Windows dependencies in order to get the script to execute properly. They must be installed and their bin folders have to be added to the Windows PATH environment variable in the Advanced System Settings screen:
+
+* UnZip for Windows compatible unzip capabilities (http://gnuwin32.sourceforge.net/packages/unzip.htm)
+    * .zip download - http://iweb.dl.sourceforge.net/project/gnuwin32/unzip/5.51-1/unzip-5.51-1-bin.zip
+* Win-Bash compatible linux bsh commands (http://sourceforge.net/projects/win-bash/?source=directory)
+    * .zip download - http://superb-dca2.dl.sourceforge.net/project/win-bash/shell-complete/latest/shell.w32-ix86.zip
+* compatible curl support (http://www.confusedbycode.com/curl/#downloads)
+* curl needs the msvc redistributable in order to function (install this before curl) - https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe
+* windows composer support (https://getcomposer.org)
+    * Binary download - https://getcomposer.org/Composer-Setup.exe
+
+Once those are completed, the rest of the instructions do work.

--- a/en/50_Open_Source/Gitify/01_Installation/02_Mac.md
+++ b/en/50_Open_Source/Gitify/01_Installation/02_Mac.md
@@ -20,10 +20,18 @@ sudo mkdir /var/mysql/
 
 ## 2. Use the right PHP binary
 
-The recommended approach would be to make sure that you're using the right PHP binary in the first place. This can be done by editing your `.bash_profile` file in your user directory, and adding the following line:
+The recommended approach would be to make sure that you're using the right PHP binary in the first place. This can be done by editing your `.bash_profile` or `.zshrc` file in your user directory, and adding the following line:
 
-```
+````
 export PATH=/Applications/MAMP/bin/php/php5.6.7/bin:$PATH
-```
+````
 
 replacing the path with the right path for your PHP install. 
+
+## 3. Use the right mysqldump and mysql binaries
+
+If you'd like to use the [backup] and [restore] commands, you'll also need to add the mysqldump and mysql binaries to your PATH. 
+
+````
+export PATH=/Applications/MAMP/Library/bin
+````

--- a/en/50_Open_Source/Gitify/01_Installation/02_Mac.md
+++ b/en/50_Open_Source/Gitify/01_Installation/02_Mac.md
@@ -1,0 +1,29 @@
+On MacOS, there's a version of PHP and MySQL installed by default. However if you use MAMP/MAMP Pro or a similar tool, it's possible that you get unexpected results trying to run Gitify from the terminal.
+
+This might include errors about missing sockets, no access to the database and stuff like that.
+
+There are two solutions to this problem. 
+
+## 1. Add a mysql socket symlink
+
+By symlinking the mysql socket in `/var/mysql/`, you will be able to communicate with the right database server. This link can sometimes get lost when the socket is closed so you might need to run this from time to time. 
+
+````
+cd /var/mysql/
+sudo ln -s /Applications/MAMP/tmp/mysql/mysql.sock
+````
+
+If the `/var/mysql/` folder doesn't exist yet, you can create it like this:
+```
+sudo mkdir /var/mysql/
+```
+
+## 2. Use the right PHP binary
+
+The recommended approach would be to make sure that you're using the right PHP binary in the first place. This can be done by editing your `.bash_profile` file in your user directory, and adding the following line:
+
+```
+export PATH=/Applications/MAMP/bin/php/php5.6.7/bin:$PATH
+```
+
+replacing the path with the right path for your PHP install. 

--- a/en/50_Open_Source/Gitify/01_Installation/index.md
+++ b/en/50_Open_Source/Gitify/01_Installation/index.md
@@ -1,0 +1,45 @@
+New as of v0.2 is that dependencies are managed via [Composer](https://getcomposer.org/), most notably it has been rebuilt on top of Symfony's Console component to provide a more feature-packed base to build from. [Follow these instructions if you haven't installed Composer before](https://getcomposer.org/doc/00-intro.md)
+
+To get started with Gitify, it's easiest to set up a local clone of this repository. It doesn't matter in which folder clone it to. On Unix/Linux systems you can choose your home directory. After that, run Composer to download the dependencies, and finally make the Gitify file executable to run it.
+
+````
+$ git clone https://github.com/modmore/Gitify.git Gitify
+$ cd Gitify
+# If you haven't installed composer, yet, you can do this to install the composer.phar:
+# curl -sS https://getcomposer.org/installer | php
+$ composer install (or php composer.phar install)
+$ chmod +x Gitify
+````
+
+At this point you should be able to type `./Gitify` and get a response like the following:
+
+```` 
+Gitify version 0.2.0
+
+Usage:
+  [options] command [arguments]
+
+Options:
+  --help           -h Display this help message.
+  --verbose        -v|vv|vvv Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+  --version        -V Display the Gitify version.
+
+Available commands:
+  build          Builds a MODX site from the files and configuration.
+  extract        Extracts data from the MODX site, and stores it in human readable files for editing and committing to a VCS.
+  help           Displays help for a command
+  init           Generates the .gitify file to set up a new Gitify project. Optionally installs MODX as well.
+  list           Lists commands
+install
+  install:modx   Downloads, configures and installs a fresh MODX installation.
+````
+
+If that's working as expected, the next step is to add the Gitify executable to your PATH so you can run Gitify in any directory. Edit your `~/.bash_profile` and add the following, with the right path to the Gitify directory (not file) of course:
+
+````
+export PATH=/path/to/Gitify/:$PATH
+````
+
+Restart your terminal and you should be good to go.
+
+For successfull installing of MODX by `Gitify install:modx` command you should have installed **unzip** command in your system. For Debian/Ubuntu you can use `sudo apt-get install unzip`.

--- a/en/50_Open_Source/Gitify/02_Commands/00_Backup.md
+++ b/en/50_Open_Source/Gitify/02_Commands/00_Backup.md
@@ -1,0 +1,17 @@
+`Gitify backup`
+
+Added in 0.7. Creates a backup of your full MySQL database. The backup will be written to the directory specified by the `backup_directory` option in your `.gitify` file. 
+
+````
+Usage:
+ backup [name]
+
+Arguments:
+ name                  Optionally the name of the backup file, useful for milestone backups. If not specified the file name will be a full timestamp.
+
+Options:
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+
+````

--- a/en/50_Open_Source/Gitify/02_Commands/01_Build.md
+++ b/en/50_Open_Source/Gitify/02_Commands/01_Build.md
@@ -1,0 +1,20 @@
+`Gitify build`
+
+Used to read the data files, and write them to the MODX database. Note that this reads the `.gitify` file to see what needs to be built; it doesn't blindly try to write any file it encounters.  
+
+As of v0.9, `Gitify build` automatically cleans up any orphaned objects it encounters. An orphaned object is an object that exists in the database, but not in the gitify files. This works on both resources and other objects. To disable orphan handling, include the `--no-cleanup` flag. Before v0.9, you had to use the `--force` attribute to ensure the database matched the files exactly. 
+
+Also as of v0.9, `Gitify build` automatically tries to resolve duplicate id/primary key conflicts for both content and other objects. Whenever it finds an object of which the real primary key (typically the ID) already exists, it will temporarily keep that object in memory. After completing the rest of the build, including the orphans clean up, it will attempt to resolve the conflict. In the case of a moved or renamed object/resource, the orphan clean up will have removed the "old" object by then, in which case the object will be inserted normally. If there is a genuine conflict (perhaps two developers added a new resource or object in separate branches), it will insert the object with a new auto incremented ID. It will also execute a `Gitify extract` in that case. 
+
+````
+Usage:
+ build [--skip-clear-cache] [-f|--force] [--no-backup]
+
+Options:
+ --skip-clear-cache    When specified, it will skip clearing the cache after building.
+ --force (-f)          When specified, all existing content will be removed before rebuilding. Can be useful when having dealt with complex conflicts.
+ --no-backup           When using the --force attribute, Gitify will automatically create a full database backup first. Specify --no-backup to skip creating the backup, at your own risk.
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+````

--- a/en/50_Open_Source/Gitify/02_Commands/02_Extract.md
+++ b/en/50_Open_Source/Gitify/02_Commands/02_Extract.md
@@ -1,0 +1,81 @@
+`Gitify extract`
+
+Used to read stuff from the MODX database, and turn it into majestic YAML data files. 
+
+````
+Usage:
+ extract
+
+Options:
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+````
+
+To give an example of the YAML data file, here's how a plugin would be stored:
+
+````
+id: 9
+name: ClientConfig
+description: 'Sets system settings from the Client Config CMP.'
+properties: null
+
+-----
+
+/**
+ * ClientConfig
+ *
+ * Copyright 2011 by Mark Hamstra <hello@markhamstra.com>
+ *
+ * ClientConfig is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * ClientConfig is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * ClientConfig; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @package clientconfig
+ *
+ * @var modX $modx
+ * @var int $id
+ * @var string $mode
+ * @var modResource $resource
+ * @var modTemplate $template
+ * @var modTemplateVar $tv
+ * @var modChunk $chunk
+ * @var modSnippet $snippet
+ * @var modPlugin $plugin
+*/
+
+$eventName = $modx->event->name;
+
+switch($eventName) {
+    case 'OnHandleRequest':
+        /* Grab the class */
+        $path = $modx->getOption('clientconfig.core_path', null, $modx->getOption('core_path') . 'components/clientconfig/');
+        $path .= 'model/clientconfig/';
+        $clientConfig = $modx->getService('clientconfig','ClientConfig', $path);
+
+        /* If we got the class (gotta be careful of failed migrations), grab settings and go! */
+        if ($clientConfig instanceof ClientConfig) {
+            $settings = $clientConfig->getSettings();
+
+            /* Make settings available as [[++tags]] */
+            $modx->setPlaceholders($settings, '+');
+
+            /* Make settings available for $modx->getOption() */
+            foreach ($settings as $key => $value) {
+                $modx->setOption($key, $value);
+            }
+        }
+        break;
+}
+
+return;
+````

--- a/en/50_Open_Source/Gitify/02_Commands/04_Init.md
+++ b/en/50_Open_Source/Gitify/02_Commands/04_Init.md
@@ -1,0 +1,14 @@
+`Gitify init`
+
+Used to create a `.gitify` file in the current directory. Interactively allows you to set up a basic configuration, and also prompts to install MODX if it's not yet present.
+
+````
+Usage:
+ init [--overwrite]
+
+Options:
+ --overwrite           When a .gitify file already exists, and this flag is set, it will be overwritten.
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+````

--- a/en/50_Open_Source/Gitify/02_Commands/05_Restore.md
+++ b/en/50_Open_Source/Gitify/02_Commands/05_Restore.md
@@ -1,0 +1,17 @@
+`Gitify restore`
+
+Added in 0.7. Restores your MySQL database from a backup created with `Gitify backup`. Specify "last" to use the most recent backup. 
+
+````
+Usage:
+ restore [file]
+
+Arguments:
+ file                  The file name of the backup to restore; if left empty you will be provided a list of available backups. Specify "last" to use the last backup, based on the file modification time.
+
+Options:
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+
+````

--- a/en/50_Open_Source/Gitify/02_Commands/06_MODX_Install.md
+++ b/en/50_Open_Source/Gitify/02_Commands/06_MODX_Install.md
@@ -1,0 +1,21 @@
+---
+title: modx:install
+---
+
+`Gitify modx:install`
+
+Renamed from `Gitify install:modx` in v0.8. Installs the latest version of MODX, or the one you specified, by downloading the zip and running a command line install. Database details and the likes will be asked for interactively.
+
+````
+Usage:
+ modx:install [modx_version]
+
+Arguments:
+ modx_version          The version of MODX to install, in the format 2.3.2-pl. Leave empty or specify "latest" to install the last stable release.
+
+Options:
+ --download (-d)       Force download the MODX package even if it already exists in the cache folder.
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+````

--- a/en/50_Open_Source/Gitify/02_Commands/07_MODX_Upgrade.md
+++ b/en/50_Open_Source/Gitify/02_Commands/07_MODX_Upgrade.md
@@ -1,0 +1,21 @@
+---
+title: modx:upgrade
+---
+
+`Gitify modx:upgrade`
+
+Downloads, configures and updates the current MODX installation. 
+
+````
+Usage:
+ modx:upgrade [modx_version]
+
+Arguments:
+ modx_version          The version of MODX to upgrade, in the format 2.3.2-pl. Leave empty or specify "latest" to install the last stable release.
+
+Options:
+ --download (-d)       Force download the MODX package even if it already exists in the cache folder.
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+````

--- a/en/50_Open_Source/Gitify/02_Commands/08_Package_Install.md
+++ b/en/50_Open_Source/Gitify/02_Commands/08_Package_Install.md
@@ -1,0 +1,23 @@
+---
+title: package:install
+---
+
+`Gitify package:install`
+
+Renamed from `Gitify install:package` in v0.8. Installs the last version of a MODX Package with the PackageName you specified, or all packages defined in your `.gitify` file when specifying the `--all` flag. 
+
+````
+Usage:
+ package:install [--all] [-i|--interactive] [package_name]
+
+Arguments:
+ PackageName          The MODX Package to install. Installs the last stable release of the Package.
+
+Options:
+ --all                 When specified, all packages defined in the .gitify config will be installed.
+ --interactive (-i)    When --all and --interactive are specified, all packages defined in the .gitify config will be installed interactively. Installing a single package is always done interactively. 
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+
+````

--- a/en/50_Open_Source/Gitify/02_Commands/index.md
+++ b/en/50_Open_Source/Gitify/02_Commands/index.md
@@ -1,0 +1,30 @@
+When you have Gitify installed, you can use `Gitify list` to get an overview of all available commands, and `Gitify help [command]` to get more information about that specific command. 
+
+````
+Gitify version 0.8.0
+
+Usage:
+ [options] command [arguments]
+
+Options:
+ --help (-h)           Display this help message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display the Gitify version.
+
+Available commands:
+ backup            Creates a quick backup of the entire MODX database. Runs automatically when using `Gitify build --force`, but can also be used manually.
+ build             Builds a MODX site from the files and configuration.
+ extract           Extracts data from the MODX site, and stores it in human readable files for editing and committing to a VCS.
+ help              Displays help for a command
+ init              Generates the .gitify file to set up a new Gitify project. Optionally installs MODX as well.
+ list              Lists commands
+ restore           Restores the MODX database from a database dump created by `Gitify backup`
+install
+ install:modx      [Deprecated, will be removed in v1] Downloads, configures and installs a fresh MODX installation. 
+ install:package   [Deprecated, will be removed in v1] Downloads and installs MODX packages. 
+modx
+ modx:install      Downloads, configures and installs a fresh MODX installation. [Note: install:modx will be removed in 1.0, use modx:install instead]
+ modx:upgrade      Ugrades an already installed MODX installation. 
+package
+ package:install   Downloads and installs MODX packages. [Note: install:package will be removed in 1.0, use package:install instead]
+````

--- a/en/50_Open_Source/Gitify/03_dot-gitify.md
+++ b/en/50_Open_Source/Gitify/03_dot-gitify.md
@@ -1,0 +1,214 @@
+---
+title: .gitify file
+---
+
+To define what to export, to where and how, we're using a `.gitify` file formatted in YAML. This file is located in the root of the project. 
+
+An example `.gitify` may look like this:
+
+````
+data_directory: _data/
+backup_directory: _backup/
+data:
+    contexts:
+        class: modContext
+        primary: key
+    context_settings:
+        class: modContextSetting
+        primary:
+            - context_key
+            - key
+    content:
+        type: content
+        exclude_keys:
+            - editedby
+            - editedon
+    categories:
+        class: modCategory
+        primary: category
+        truncate_on_force:
+            - modCategoryClosure
+    templates:
+        class: modTemplate
+        primary: templatename
+        extension: .html
+    template_variables:
+        class: modTemplateVar
+        primary: name
+    template_variables_access:
+        class: modTemplateVarTemplate
+        primary:
+            - tmplvarid
+            - templateid
+    chunks:
+        class: modChunk
+        primary: name
+        extension: .html
+    snippets:
+        class: modSnippet
+        primary: name
+        extension: .php
+    plugins:
+        class: modPlugin
+        primary: name
+        extension: .php
+    plugin_events:
+        class: modPluginEvent
+        primary:
+            - pluginid
+            - event
+    events:
+        class: modEvent
+        primary: name
+    namespaces:
+        class: modNamespace
+        primary: name
+    system_settings:
+        class: modSystemSetting
+        primary: key
+        where:
+            - 'editedon:!=': '0000-00-00 00:00:00'
+        exclude_keys:
+            - editedon
+    extension_packages:
+        class: modExtensionPackage
+        primary: namespace
+        exclude_keys:
+            - created_at
+            - updated_at
+    fc_sets:
+        class: modFormCustomizationSet
+        primary: id
+    fc_profiles:
+        class: modFormCustomizationProfile
+        primary: id
+    fc_profile_usergroups:
+        class: modFormCustomizationProfileUserGroup
+        primary:
+            - usergroup
+            - profile
+    fc_action_dom:
+        class: modActionDom
+        primary:
+            - set
+            - name
+    mediasources:
+        class: modMediaSource
+        primary: id
+    mediasource_elements:
+        class: sources.modMediaSourceElement
+        primary:
+            - source
+            - object_class
+            - object
+            - context_key
+    dashboards:
+        class: modDashboard
+        primary:
+            - id
+            - name
+    dashboard_widgets:
+        class: modDashboardWidget
+        primary: id
+    dashboard_widget_placement:
+        class: modDashboardWidgetPlacement
+        primary:
+            - dashboard
+            - widget
+````
+
+The `.gitify` file structure is real simple. There are root nodes for `data_directory` (the relative path where to store the files), `backup_directory`, `data` and `packages`. 
+
+`data` contains an array of what we call "Partitions". These partitions are basically the name of the directory that holds all the files of that type, and can also be used in the `Gitify extract` and `Gitify build` commands. Each partition specifies either a `type` that has special processing going on (only `content` is available as type currently), or a `class` which specified the xPDOObject derivative that you want to use. The `primary` field determines the key to use in the name of the generated files. This defaults to `id`, but in many cases you may want to use the `name` as that is more human friendly. The primary is used for the file names and is also related to the automatic ID conflict resolution.
+
+By default files will be created with a `.yaml` extension, but if you want you can override that with a `extension` property. This can help with syntax highlighting in IDEs.
+
+Each partition can also specify a `where` property. This contains an array which can be turned into a valid xPDO criteria. 
+
+When using GitifyWatch, there is also an `environments` root node in the gitify file, refer to the GitifyWatch documentation for more about that. 
+
+### Third party packages (models)
+
+When a certain class is not part of the core models, you can define a `package` as well. This will run `$modx->addPackage` before attempting to load the data. The path is determined by looking at a `[package].core_path` setting suffixed with `model/`, `[[++core_path]]components/[package]/model/`or a hardcoded `package_path` property. For example, you could use the following in your `.gitify` file to load [ContentBlocks](http://modmo.re/cb) Layouts &amp; Fields:
+
+```` 
+data:
+    cb_fields:
+        class: cbField
+        primary: name
+        package: contentblocks
+    cb_layouts:
+        class: cbLayout
+        primary: name
+````
+
+As it'll load the package into memory, it's only required to add the package once. For clarify, it can't hurt to add it to each `data` entry that uses it.
+
+### Dealing with Closures
+
+A Closure is a separate table in the database that a core or third party extra may use to keep information about a hierarchy in a convenient format. These are often automatically generated when creating a new object, which can result in a error messages and other issues when building, especially with the `--force` flag. 
+
+To solve this, a `truncate_on_force` option was introduced in v0.6.0 that lets you define an array of class names that need their tables truncated on a force build. Truncating the closure table(s) before a forced build ensures that the model can properly create the rows in the closure table, without throwing errors.
+
+Here are two examples of using `truncate_on_force`:
+
+````
+data:
+    categories:
+        class: modCategory
+        primary: category
+        truncate_on_force:
+            - modCategoryClosure
+
+    quip_comments:
+        class: quipComment
+        package: quip
+        primary: [thread, id]
+        truncate_on_force: 
+            - quipCommentClosure
+````
+
+### Composite Primary Keys
+
+When an object doesn't have a single primary key, or you want to get fancy with file names, it's possible to define a composite primary key, by setting the `primary` attribute to an array. For example, like this:
+
+````
+data:
+    chunks:
+        class: modChunk
+        primary: [category, name]
+        extension: .html
+````
+
+That would grab the category and the name as primary keys, and join them together with a dot in the file name. This is a pretty bad example, and you shouldn't really use it like this.
+
+### Install MODX Packages
+
+You can also define packages to install with the `Gitify package:install --all` command. This uses the following format
+
+````
+packages:
+        modx.com:
+            service_url: http://rest.modx.com/extras/
+            packages:
+                - ace
+                - wayfinder
+        modmore.com:
+            service_url: https://rest.modmore.com/
+            credential_file: '.modmore.com.key'
+            packages:
+                - clientconfig
+````
+
+When a provider needs to be authenticated, like modmore.com the example above, you can provide a `credential_file` option which points to a file name. This file needs to contain a `username` and `api_key` value (in YAML format), like so:
+
+````
+username: my_api_key_username
+api_key: some_api_key_password
+````
+
+Alternatively, you can also define the username and api_key directly on the provider information in the .gitify file, but the credential_file approach is recommended to be able of keeping your authentication outside of the repository. 
+
+For security, the key file needs to be kept out of the git repository using a .gitignore file, and you will also want to protect direct read access to it with your .htaccess file or keeping it out of the webroot.
+
+To install the packages that you added to the `packages` entry in the .gitify file, simply run the command `Gitify package:install --all`. That will attempt to install all packages that were mentioned, skipping any that are already installed. 

--- a/en/50_Open_Source/Gitify/04_Data_Files.md
+++ b/en/50_Open_Source/Gitify/04_Data_Files.md
@@ -1,0 +1,95 @@
+Data files are formatted in a combination of YAML and a content area if the object has a getContent method defined.
+
+The top of the file contains the YAML meta data. This includes most of the objects' fields. 
+
+The separator is a blank line, followed by five dashes (`-----`) and another blank line. Anything before the separator is the YAML data, everything below it is the content.
+
+## YAML Formatting Notes
+
+When manually editing the data files, to build into MODX later, it's important to keep a few things in mind.
+
+1. Strings can be edited with or without quotes, however as soon as there's any non-alphanumeric characters inside the string (dots, slashes, brackets etc), there should be single or double quotes around the value. Otherwise, you might get a YAML parse error on build.
+2. _No_ commas at the end of a line; the line break is enough.
+3. Use the [YAML Linter](http://www.yamllint.com/) if you get a YAML parse error but can't figure out what's causing it. Don't include the separator or content below it though.
+
+## Example data files
+
+This example only has simple meta data (Redirector Redirect object):
+
+````
+id: 2
+pattern: ^redactor$
+target: extras/redactor/
+context_key: web
+triggered: 257
+triggered_first: '2014-08-02 06:32:29'
+triggered_last: '2014-08-03 13:18:51'
+````
+
+This example shows the YAML meta data, followed by the content (the ClientConfig plugin):
+
+````
+id: 9
+name: ClientConfig
+description: 'Sets system settings from the Client Config CMP.'
+properties: null
+
+-----
+
+/**
+ * ClientConfig
+ *
+ * Copyright 2011 by Mark Hamstra <hello@markhamstra.com>
+ *
+ * ClientConfig is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * ClientConfig is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * ClientConfig; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @package clientconfig
+ *
+ * @var modX $modx
+ * @var int $id
+ * @var string $mode
+ * @var modResource $resource
+ * @var modTemplate $template
+ * @var modTemplateVar $tv
+ * @var modChunk $chunk
+ * @var modSnippet $snippet
+ * @var modPlugin $plugin
+*/
+
+$eventName = $modx->event->name;
+
+switch($eventName) {
+    case 'OnHandleRequest':
+        /* Grab the class */
+        $path = $modx->getOption('clientconfig.core_path', null, $modx->getOption('core_path') . 'components/clientconfig/');
+        $path .= 'model/clientconfig/';
+        $clientConfig = $modx->getService('clientconfig','ClientConfig', $path);
+
+        /* If we got the class (gotta be careful of failed migrations), grab settings and go! */
+        if ($clientConfig instanceof ClientConfig) {
+            $settings = $clientConfig->getSettings();
+
+            /* Make settings available as [[++tags]] */
+            $modx->setPlaceholders($settings, '+');
+
+            /* Make settings available for $modx->getOption() */
+            foreach ($settings as $key => $value) {
+                $modx->setOption($key, $value);
+            }
+        }
+        break;
+}
+
+return;
+````

--- a/en/50_Open_Source/Gitify/05_Updating_Gitify.md
+++ b/en/50_Open_Source/Gitify/05_Updating_Gitify.md
@@ -1,0 +1,19 @@
+If you followed the procedure to install Gitify from Git, updating Gitify to a newer version is as simple as pulling in the recent changes. 
+
+Just pull in the latest changes, rerun composer in case anything changed with regards to the dependencies, and off you go.
+
+````
+cd /path/to/Gitify/
+git pull
+composer install
+````
+
+## Dealing with breaking changes
+
+Especially in early releases, it's not uncommon for breaking changes to occur. These changes might be related to how the files get written - or read - and can break your workflow. Any potentially breaking changes are tagged with `[BC]` in [the changelog](https://github.com/modmore/Gitify/blob/master/CHANGELOG.md).
+
+The easiest way to deal with changes like this is to make sure that, before updating, there are no differences between your data files and the database. So extract or build before updating.
+
+After the update, extract again so files are written anew and are compatible with whatever changed in the new release. Otherwise you may not be able to build later.
+
+Remember to update all your Gitify installs (local, staging and production) as close to each other as possible to be safe from changes between versions. It's also possible to install Gitify into your project files (as git submodule - tho we might add it to composer later), so you have a copy of Gitify local to the project, but then you lose the ability to run it anywhere.

--- a/en/50_Open_Source/Gitify/06_Examples.md
+++ b/en/50_Open_Source/Gitify/06_Examples.md
@@ -1,0 +1,279 @@
+## Default
+
+When using `Gitify init` and answering Yes to all questions, and keeping the data directory as the default, this is the `.gitify` file you and up with:
+
+````
+data_directory: _data/
+backup_directory: _backup/
+data:
+    contexts:
+        class: modContext
+        primary: key
+    context_settings:
+        class: modContextSetting
+        primary:
+            - context_key
+            - key
+    template_variables:
+        class: modTemplateVar
+        primary: name
+    template_variables_access:
+        class: modTemplateVarTemplate
+        primary:
+            - tmplvarid
+            - templateid
+    content:
+        type: content
+        exclude_keys:
+            - editedby
+            - editedon
+        truncate_on_force:
+            - modTemplateVarResource
+    categories:
+        class: modCategory
+        primary: category
+        truncate_on_force:
+            - modCategoryClosure
+    templates:
+        class: modTemplate
+        primary: templatename
+        extension: .html
+    chunks:
+        class: modChunk
+        primary: name
+        extension: .html
+    snippets:
+        class: modSnippet
+        primary: name
+        extension: .php
+    plugins:
+        class: modPlugin
+        primary: name
+        extension: .php
+    plugin_events:
+        class: modPluginEvent
+        primary:
+            - pluginid
+            - event
+    events:
+        class: modEvent
+        primary: name
+    namespaces:
+        class: modNamespace
+        primary: name
+    system_settings:
+        class: modSystemSetting
+        primary: key
+        exclude_keys:
+            - editedon
+    extension_packages:
+        class: modExtensionPackage
+        primary: namespace
+        exclude_keys:
+            - created_at
+            - updated_at
+    fc_sets:
+        class: modFormCustomizationSet
+        primary: id
+    fc_profiles:
+        class: modFormCustomizationProfile
+        primary: id
+    fc_profile_usergroups:
+        class: modFormCustomizationProfileUserGroup
+        primary:
+            - usergroup
+            - profile
+    fc_action_dom:
+        class: modActionDom
+        primary:
+            - set
+            - name
+    mediasources:
+        class: modMediaSource
+        primary: id
+    mediasource_elements:
+        class: sources.modMediaSourceElement
+        primary:
+            - source
+            - object_class
+            - object
+            - context_key
+    dashboards:
+        class: modDashboard
+        primary:
+            - id
+            - name
+    dashboard_widgets:
+        class: modDashboardWidget
+        primary: id
+    dashboard_widget_placement:
+        class: modDashboardWidgetPlacement
+        primary:
+            - dashboard
+            - widget
+````
+
+## Including other XPDO objects 
+
+To include ACL-related objects, that is Policies and PolicyTemplates, the following additional data part should do the trick. _Note: these configuration is currently not asked by the init command!_
+
+```` 
+    access_policy_templates:
+        class: modAccessPolicyTemplate
+        primary:
+            - id
+            - name
+    access_policy:
+        class: modAccessPolicy
+        primary:
+            - id
+            - name
+    access_policy_template_group:
+        class: modAccessPolicyTemplateGroup
+        primary:
+            - id
+            - name
+````
+
+## Almost a full site
+
+Keep adding stuff to it, and you might end up with something more like this:
+
+````
+name: modmore.com
+data_directory: _data/
+data:
+  contexts:
+    class: modContext
+    primary: key
+  context_settings:
+    class: modContextSetting
+    primary: [context_key, key]
+    exclude_keys:
+      - editedon
+  content:
+    type: content
+    exclude_keys:
+      - editedby
+      - editedon
+  categories:
+    class: modCategory
+    primary: category
+  templates:
+    class: modTemplate
+    primary: templatename
+  template_variables:
+    class: modTemplateVar
+    primary: name
+  template_variables_access:
+    class: modTemplateVarTemplate
+    primary: [tmplvarid, templateid]
+  chunks:
+    class: modChunk
+    primary: name
+  snippets:
+    class: modSnippet
+    primary: name
+    extension: .php
+  plugins:
+    class: modPlugin
+    primary: name
+    extension: .php
+  plugin_events:
+    class: modPluginEvent
+    primary: [pluginid,event]
+
+  events:
+    class: modEvent
+    primary: name
+  namespaces:
+    class: modNamespace
+    primary: name
+  extension_packages:
+    class: modExtensionPackage
+    primary: namespace
+  action:
+    class: modAction
+    primary: [id, namespace]
+  system_settings:
+    class: modSystemSetting
+    primary: key
+    exclude_keys:
+      - editedon
+
+  cb_fields:
+    class: cbField
+    primary: [id, name]
+    package: contentblocks
+  cb_layouts:
+    class: cbLayout
+    primary: [id, name]
+  cb_templates:
+    class: cbTemplate
+    primary: [id, name]
+  redirects:
+    class: modRedirect
+    primary: id
+    package: redirector
+  clientconfig_groups:
+    class: cgGroup
+    primary: label
+    package: clientconfig
+  clientconfig_settings:
+    class: cgSetting
+    primary: key
+  faq_set:
+    class: faqManSet
+    primary: name
+    package: faqman
+  faq_item:
+    class: faqManItem
+    primary: id
+  moregallery_image:
+    class: mgImage
+    primary: [resource, id]
+    package: moregallery
+    exclude_keys:
+      - editedon
+      - mgr_thumb_path
+      - file_url
+      - file_path
+      - view_url
+  moregallery_image_tag:
+    class: mgImageTag
+    primary: id
+  moregallery_tag:
+    class: mgTag
+    primary: display
+  polls_category:
+    class: modPollCategory
+    primary: name
+    package: polls
+  polls_question:
+    class: modPollQuestion
+    primary: id
+  polls_answer:
+    class: modPollAnswer
+    primary: [question, id]
+  scheduler_task:
+    class: sTask
+    primary: [namespace, reference]
+    package: scheduler
+
+  migx_formtab:
+    class: migxFormtab
+    primary: [id, caption]
+    package: migx
+  migx_formtab_field:
+    class: migxFormtabField
+    primary: [id, field]
+  migx_config_element:
+    class: migxConfigElement
+    primary: id
+  migx_element:
+    class: migxElement
+    primary: id
+  migx_config:
+    class: migxConfig
+    primary: [id, name]
+````

--- a/en/50_Open_Source/Gitify/07_Installing_a_Gitify_Project.md
+++ b/en/50_Open_Source/Gitify/07_Installing_a_Gitify_Project.md
@@ -1,0 +1,93 @@
+When you built a site with Gitify, and committed the data to a repository, you will at some point need to use the data to set up a copy of that site. This tutorial outlines that process. 
+
+## Table of contents
+
+[TOC]
+
+## Prerequisites
+To install a gitify project you first have to install Gitify:
+
+* [Install Gitify](Installation)
+
+After it has been installed globally we can start installing the project:
+## Cloning and Configuring
+First we clone the repository inside a new project folder:
+
+    git clone REPOSITORY-LINK PROJECT-NAME
+
+Once your project has been cloned go into that projects directory. 
+Now open `.gitify` and configure it to your liking. If you are using a custom repository like the one from ModMore you should edit the repository details to authenticate to that repository.
+
+## Installing MODX
+Now we are ready to tell gitify to install the latest MODX and all needed packages:
+
+    Gitify install:modx
+After you've used this command Gitify will ask you some questions, if you didn't create a database yet you can put in the details of a MySQL user who has the rights to create databases.
+
+The result should look like this:
+
+    Downloading MODX from http://modx.com/download/latest/...
+    ################################################ 100.0%
+    Extracting zip...
+    Moving unzipped files out of temporary directory...
+    Please complete following details to install MODX. Leave empty to use the [default].
+    Database Name [gitify_test]: 
+    Database User [root]: root
+    Database Password: 
+    Hostname [robin]: localhost
+    Base URL [/]: /gitify_test/
+    Manager Language [en]: 
+    Manager User [gitify_test_admin]: admin
+    Database Password [generated]: 
+    Manager Email: gitify@gmail.com
+    Running MODX Setup...
+    Done! Time: 133,557ms | Memory Usage: 2.25 mb | Peak Memory Usage: 2.31 mb
+
+## Installing the packages
+
+MODX has now been freshly installed and is now ready to have extras installed. But installing them one by one is going to be a hassle so we're just gonna execute this command:
+
+    Gitify install:package --all
+
+This command installs all the packages defined in `.gitify`, the result should look something like this:
+
+    Searching Provider for Ace...
+    Downloading Ace (1.5.0)...
+    Installing Ace...
+    Package Ace installed
+    
+    Searching Provider for BigBrother...
+    Downloading Big Brother (1.1.0)...
+    Installing BigBrother...
+    Package BigBrother installed
+    
+    Etc.    
+
+## Building the project
+After all the packages are installed we are ready to complete the project installation with this command:
+
+    Gitify build --force
+
+The result should look something like this, don't worry if it generates some errors about MySQL queries it should still work.
+
+    Building modContext from contexts/...
+    Building modContextSetting from context_settings/...
+    Building content from content/...
+    Forcing build, removing prior Resources...
+    - Building web context...
+    Building modCategory from categories/...
+    Building modTemplate from templates/...
+    Building modTemplateVar from template_variables/...
+    Building modTemplateVarTemplate from template_variables_access/...
+	.....
+    Clearing cache...
+    Done! Time: 9,603ms | Memory Usage: 15.65 mb | Peak Memory Usage: 17.97 mb
+
+Your project has now been installed!
+
+## Permissions
+If you are on a *nix machine and got issues with pages staying white it probably has to do with permissions. To fix this, please use these commands in the root of your project:
+
+    chmod 777 assets
+    chmod 777 -R assets/components core/cache core/components core/packages
+If it gives you permission denied errors try to use `sudo` in front of every command.

--- a/en/50_Open_Source/Gitify/09_Troubleshooting.md
+++ b/en/50_Open_Source/Gitify/09_Troubleshooting.md
@@ -1,0 +1,7 @@
+# Troubleshooting
+
+Having issues with Gitify? Please read all entries in this guide and search the [issues on Github](https://github.com/modmore/Gitify/issues). If you don't find an answer you might want to [open a new issue](https://github.com/modmore/Gitify/issues/new).
+
+## MIGX
+
+If you're using MIGX configs and the Gitify files for the configs changes after each `build` and `extract` command of Gitify, you might need to pay attention to your order of the MIGX objects in your `.gitify` file. The `migxConfig` should be the last item of the MIGX objects. For more details please read [issue #90](https://github.com/modmore/Gitify/issues/90).

--- a/en/50_Open_Source/Gitify/index.md
+++ b/en/50_Open_Source/Gitify/index.md
@@ -1,5 +1,7 @@
 [Gitify](https://github.com/modmore/Gitify/) is a set of command-line commands that can be used for versioning and dev-stage-production workflows with a MODX site. Its primary purpose is to create file representations of objects in the MODX database (such as resources and elements, but any object can be included), so they can be committed to a version control system such as git.
 
+The project configuration, which determines what data is written to file and build to the database, is stored in a [.gitify file](dot-gitify) in the project root.
+
 [Gitify Watch](https://www.modmore.com/gitifywatch/) is a free companion MODX Extra for Gitify, which will automatically extract information from MODX when changes are made. 
 
 Gitify was first introduced at the MODX Weekend 2014. [A video of that talk is available here](https://video.modmore.com/modx-weekend-2014/sunday-backend/staging-workflow-with-git-and-gitify/). [Slides of the MODXpo 2015 talk can be found here](http://www.slideshare.net/hamstramark1/dev-staging-production-workflow-with-gitify-at-modxpo-2015-in-munich), which walks you through the purpose of Gitify and how the process can be set up.

--- a/en/50_Open_Source/Gitify/index.md
+++ b/en/50_Open_Source/Gitify/index.md
@@ -1,0 +1,5 @@
+[Gitify](https://github.com/modmore/Gitify/) is a set of command-line commands that can be used for versioning and dev-stage-production workflows with a MODX site. Its primary purpose is to create file representations of objects in the MODX database (such as resources and elements, but any object can be included), so they can be committed to a version control system such as git.
+
+[Gitify Watch](https://www.modmore.com/gitifywatch/) is a free companion MODX Extra for Gitify, which will automatically extract information from MODX when changes are made. 
+
+Gitify was first introduced at the MODX Weekend 2014. [A video of that talk is available here](https://video.modmore.com/modx-weekend-2014/sunday-backend/staging-workflow-with-git-and-gitify/). [Slides of the MODXpo 2015 talk can be found here](http://www.slideshare.net/hamstramark1/dev-staging-production-workflow-with-gitify-at-modxpo-2015-in-munich), which walks you through the purpose of Gitify and how the process can be set up.


### PR DESCRIPTION
There's documentation both at https://github.com/modmore/Gitify/wiki and http://modmore.github.io/Gitify/ so I'm trying to combine those into one here. 

One challenge is that the latter is also in Russian (source files are at https://github.com/modmore/Gitify/tree/gh-pages/_posts) and we might need to add some sort of language switch to the docs site first. Also not sure how to handle all other docs only being in English.. Thoughts @christianseel?