### PR TITLE
Update deprecated Commerce event

### DIFF
--- a/en/01_Commerce/v1/75_Developer/Example_Modules/Add_Order_View_button.md
+++ b/en/01_Commerce/v1/75_Developer/Example_Modules/Add_Order_View_button.md
@@ -30,7 +30,7 @@ class AddOrderButton extends BaseModule
 
     public function initialize(EventDispatcher $dispatcher)
     {
-        $dispatcher->addListener(\Commerce::EVENT_ORDER_GET_ACTIONS, array($this, 'addButton'));
+        $dispatcher->addListener(\Commerce::EVENT_DASHBOARD_ORDER_ACTIONS, array($this, 'addButton'));
     }
 
     public function addButton(OrderActions $event)


### PR DESCRIPTION
EVENT_ORDER_GET_ACTIONS is deprecated (from line 77 in commerce.class.php)