### PR TITLE
Add loadOrderFields property for commerce.get_cart snippet

### DIFF
--- a/en/01_Commerce/v1/10_Snippets/get_cart.md
+++ b/en/01_Commerce/v1/10_Snippets/get_cart.md
@@ -23,6 +23,7 @@ Added in v0.7.
 - `&toPlaceholders`: prefix to use for setting placeholders with all cart information.
 - `&field`: specify an order field to return only that field.
 - `&separator`: string to use to join the product records together, defaults to a newline character. (new in 0.11)
+- `&loadOrderFields`: loads custom order fields under an order_fields array in the response, defaults to enabled. (added in 1.1)
 
 ## Returning information
 


### PR DESCRIPTION
Add the loadOrderFields property to the documentation on the commerce.get_cart snippet (added in internal PR 465).