### PR TITLE
Corrected json story.label value to match image

### DIFF
--- a/en/03_MoreGallery/v1.x/04_Custom_Fields.md
+++ b/en/03_MoreGallery/v1.x/04_Custom_Fields.md
@@ -12,7 +12,7 @@ Note that these custom fields are not built in a way that they are easily search
 ```` javascript   
 {
     "story":{
-        "label":"Story behind this image",
+        "label":"How this picture was made",
         "type":"richtext"
     },
     "copyright":{


### PR DESCRIPTION
The story.label value was 'Story behind this image' which doesn't appear in the screengrab.